### PR TITLE
added ofColor conversion to IM_VEC4_CLASS_EXTRA

### DIFF
--- a/src/imconfig.h
+++ b/src/imconfig.h
@@ -37,6 +37,7 @@
 
 #define MyVec2 ofVec2f
 #define MyVec4 ofVec4f
+#define MyColor ofColor
 
 #define IM_VEC2_CLASS_EXTRA                                                 \
 ImVec2(const MyVec2& f) { x = f.x; y = f.y; }                       \
@@ -44,7 +45,9 @@ operator MyVec2() const { return MyVec2(x,y); }
 
 #define IM_VEC4_CLASS_EXTRA                                                 \
 ImVec4(const MyVec4& f) { x = f.x; y = f.y; z = f.z; w = f.w; }     \
-operator MyVec4() const { return MyVec4(x,y,z,w); }
+operator MyVec4() const { return MyVec4(x,y,z,w); }     \
+ImVec4(const MyColor& f) { float sc = 1.0f/255.0f; x = f.r*sc; y = f.g*sc; z = f.b*sc; w = f.a*sc; }  \
+operator MyColor() const { return MyColor((int) (x*255.0f+0.5f), (int) (y*255.0f+0.5f), (int) (z*255.0f+0.5f), (int) (w*255.0f+0.5f)); }
 
 #define ImDrawIdx ofIndexType
 


### PR DESCRIPTION
This will allow use ofColor objects for all ImGui functions.  It will also remove the need to for the color conversion functions in BaseTheme.