### PR TITLE
Modified MousePressed and MouseReleased action to catch all clicks

### DIFF
--- a/src/BaseEngine.cpp
+++ b/src/BaseEngine.cpp
@@ -23,7 +23,7 @@ void BaseEngine::onKeyPressed(ofKeyEventArgs& event)
 
 void BaseEngine::onMouseDragged(ofMouseEventArgs& event)
 {
-    mouseDragged = true;
+    mouseReleased = false;
 }
 
 void BaseEngine::onMousePressed(ofMouseEventArgs& event)
@@ -31,12 +31,13 @@ void BaseEngine::onMousePressed(ofMouseEventArgs& event)
     if(event.button >= 0 && event.button < 5)
     {
         mousePressed[event.button] = true;
+        mouseReleased = false;
     }
 }
 
 void BaseEngine::onMouseReleased(ofMouseEventArgs& event)
 {
-    mouseDragged = false;
+    mouseReleased = true;
 }
 
 void BaseEngine::onMouseScrolled(ofMouseEventArgs& event)

--- a/src/BaseEngine.cpp
+++ b/src/BaseEngine.cpp
@@ -25,19 +25,12 @@ void BaseEngine::onMousePressed(ofMouseEventArgs& event)
 {
     if(event.button >= 0 && event.button < 5)
     {
-        ImGuiIO& io = ImGui::GetIO();
-        io.MouseDown[event.button] = true;
+        mousePressed[event.button] = true;
     }
 }
 
 void BaseEngine::onMouseReleased(ofMouseEventArgs& event)
-{
-    if(event.button >= 0 && event.button < 5)
-    {
-        ImGuiIO& io = ImGui::GetIO();
-        io.MouseDown[event.button] = false;
-    }
-}
+{}
 
 void BaseEngine::onMouseScrolled(ofMouseEventArgs& event)
 {

--- a/src/BaseEngine.cpp
+++ b/src/BaseEngine.cpp
@@ -21,6 +21,11 @@ void BaseEngine::onKeyPressed(ofKeyEventArgs& event)
     //io->AddInputCharacter((unsigned short)event.codepoint);
 }
 
+void BaseEngine::onMouseDragged(ofMouseEventArgs& event)
+{
+    mouseDragged = true;
+}
+
 void BaseEngine::onMousePressed(ofMouseEventArgs& event)
 {
     if(event.button >= 0 && event.button < 5)
@@ -30,7 +35,9 @@ void BaseEngine::onMousePressed(ofMouseEventArgs& event)
 }
 
 void BaseEngine::onMouseReleased(ofMouseEventArgs& event)
-{}
+{
+    mouseDragged = false;
+}
 
 void BaseEngine::onMouseScrolled(ofMouseEventArgs& event)
 {

--- a/src/BaseEngine.h
+++ b/src/BaseEngine.h
@@ -44,6 +44,7 @@ public:
     static unsigned int g_VboHandle;
     static unsigned int g_ElementsHandle;
 
+    int mousePressed[5] = {0};
 protected:
     bool isSetup;
 };

--- a/src/BaseEngine.h
+++ b/src/BaseEngine.h
@@ -46,7 +46,7 @@ public:
     static unsigned int g_ElementsHandle;
 
     bool mousePressed[5] = {false};
-    bool mouseDragged = false;
+    bool mouseReleased = true;
 protected:
     bool isSetup;
 };

--- a/src/BaseEngine.h
+++ b/src/BaseEngine.h
@@ -19,6 +19,7 @@ public:
     virtual bool createDeviceObjects()=0;
     virtual void invalidateDeviceObjects()=0;
 
+    virtual void onMouseDragged(ofMouseEventArgs& event);
     virtual void onMousePressed(ofMouseEventArgs& event);
     virtual void onMouseReleased(ofMouseEventArgs& event);
     virtual void onMouseScrolled(ofMouseEventArgs& event);
@@ -44,7 +45,8 @@ public:
     static unsigned int g_VboHandle;
     static unsigned int g_ElementsHandle;
 
-    int mousePressed[5] = {0};
+    bool mousePressed[5] = {false};
+    bool mouseDragged = false;
 protected:
     bool isSetup;
 };

--- a/src/EngineGLFW.cpp
+++ b/src/EngineGLFW.cpp
@@ -108,6 +108,7 @@ void EngineGLFW::onMousePressed(ofMouseEventArgs& event)
     {
         remapToGLFWConvention(button);
         mousePressed[button] = true;
+        mouseReleased = false;
     }
 }
 

--- a/src/EngineGLFW.cpp
+++ b/src/EngineGLFW.cpp
@@ -105,21 +105,12 @@ void EngineGLFW::onMousePressed(ofMouseEventArgs& event)
     if(button >= 0 && button < 5)
     {
         remapToGLFWConvention(button);
-        ImGuiIO& io = ImGui::GetIO();
-        io.MouseDown[button] = true;
+        mousePressed[button] = true;
     }
 }
 
 void EngineGLFW::onMouseReleased(ofMouseEventArgs& event)
-{
-    int button = event.button;
-    if(button >= 0 && button < 5)
-    {
-        remapToGLFWConvention(button);
-        ImGuiIO& io = ImGui::GetIO();
-        io.MouseDown[button] = false;
-    }
-}
+{}
 
 void EngineGLFW::programmableRenderDrawLists(ImDrawData * draw_data)
 {

--- a/src/EngineGLFW.cpp
+++ b/src/EngineGLFW.cpp
@@ -47,11 +47,12 @@ void EngineGLFW::setup()
 
     // Override listeners
     ofAddListener(ofEvents().mousePressed, this, &EngineGLFW::onMousePressed);
-    ofAddListener(ofEvents().mouseReleased, this, &EngineGLFW::onMouseReleased);
     ofAddListener(ofEvents().keyReleased, this, &EngineGLFW::onKeyReleased);
     
     // BaseEngine listeners
     ofAddListener(ofEvents().keyPressed, (BaseEngine*)this, &BaseEngine::onKeyPressed);
+    ofAddListener(ofEvents().mouseDragged, (BaseEngine*)this, &BaseEngine::onMouseDragged);
+    ofAddListener(ofEvents().mouseReleased, (BaseEngine*)this, &BaseEngine::onMouseReleased);
     ofAddListener(ofEvents().mouseScrolled, (BaseEngine*)this, &BaseEngine::onMouseScrolled);
     ofAddListener(ofEvents().windowResized, (BaseEngine*)this, &BaseEngine::onWindowResized);
 
@@ -64,11 +65,12 @@ void EngineGLFW::exit()
 
     // Override listeners
     ofRemoveListener(ofEvents().mousePressed, this, &EngineGLFW::onMousePressed);
-    ofRemoveListener(ofEvents().mouseReleased, this, &EngineGLFW::onMouseReleased);
     ofRemoveListener(ofEvents().keyReleased, this, &EngineGLFW::onKeyReleased);
 
     // Base class listeners
     ofRemoveListener(ofEvents().keyPressed, (BaseEngine*)this, &BaseEngine::onKeyPressed);
+    ofRemoveListener(ofEvents().mouseDragged, (BaseEngine*)this, &BaseEngine::onMouseDragged);
+    ofRemoveListener(ofEvents().mouseReleased, (BaseEngine*)this, &BaseEngine::onMouseReleased);
     ofRemoveListener(ofEvents().mouseScrolled, (BaseEngine*)this, &BaseEngine::onMouseScrolled);
     ofRemoveListener(ofEvents().windowResized, (BaseEngine*)this, &BaseEngine::onWindowResized);
 
@@ -108,9 +110,6 @@ void EngineGLFW::onMousePressed(ofMouseEventArgs& event)
         mousePressed[button] = true;
     }
 }
-
-void EngineGLFW::onMouseReleased(ofMouseEventArgs& event)
-{}
 
 void EngineGLFW::programmableRenderDrawLists(ImDrawData * draw_data)
 {

--- a/src/EngineGLFW.h
+++ b/src/EngineGLFW.h
@@ -20,7 +20,6 @@ public:
     
     void onKeyReleased(ofKeyEventArgs& event) override;
     void onMousePressed(ofMouseEventArgs& event) override;
-    void onMouseReleased(ofMouseEventArgs& event) override;
     
     // Custom 
     static void programmableRenderDrawLists(ImDrawData * draw_data);

--- a/src/EngineOpenGLES.cpp
+++ b/src/EngineOpenGLES.cpp
@@ -34,6 +34,7 @@ void EngineOpenGLES::setup()
     
     // BaseEngine listeners
     ofAddListener(ofEvents().keyPressed, (BaseEngine*)this, &BaseEngine::onKeyPressed);
+    ofAddListener(ofEvents().mouseDragged, (BaseEngine*)this, &BaseEngine::onMouseDragged);
     ofAddListener(ofEvents().mousePressed, (BaseEngine*)this, &BaseEngine::onMousePressed);
     ofAddListener(ofEvents().mouseReleased, (BaseEngine*)this, &BaseEngine::onMouseReleased);
     ofAddListener(ofEvents().mouseScrolled, (BaseEngine*)this, &BaseEngine::onMouseScrolled);
@@ -51,6 +52,7 @@ void EngineOpenGLES::exit()
 
     // BaseEngine listeners
     ofRemoveListener(ofEvents().keyPressed, (BaseEngine*)this, &BaseEngine::onKeyPressed);
+    ofRemoveListener(ofEvents().mouseDragged, (BaseEngine*)this, &BaseEngine::onMouseDragged);
     ofRemoveListener(ofEvents().mousePressed, (BaseEngine*)this, &BaseEngine::onMousePressed);
     ofRemoveListener(ofEvents().mouseReleased, (BaseEngine*)this, &BaseEngine::onMouseReleased);
     ofRemoveListener(ofEvents().mouseScrolled, (BaseEngine*)this, &BaseEngine::onMouseScrolled);

--- a/src/ofxImGui.cpp
+++ b/src/ofxImGui.cpp
@@ -121,7 +121,12 @@ void ofxImGui::begin()
     }
     lastTime = currentTime;
     
+    // Update Settings
     io.MousePos = ImVec2((float)ofGetMouseX(), (float)ofGetMouseY());
+    for(int i = 0; i < 5; i++){
+        io.MouseDown[i] = engine->mousePressed[i];
+        engine->mousePressed[i] = false;
+    }
     ImGui::NewFrame();
 }
 

--- a/src/ofxImGui.cpp
+++ b/src/ofxImGui.cpp
@@ -125,7 +125,7 @@ void ofxImGui::begin()
     io.MousePos = ImVec2((float)ofGetMouseX(), (float)ofGetMouseY());
     for(int i = 0; i < 5; i++){
         io.MouseDown[i] = engine->mousePressed[i];
-        engine->mousePressed[i] = false;
+        engine->mousePressed[i] = engine->mouseDragged || false;    // Don't set to false if the mouse is being dragged
     }
     ImGui::NewFrame();
 }

--- a/src/ofxImGui.cpp
+++ b/src/ofxImGui.cpp
@@ -125,7 +125,9 @@ void ofxImGui::begin()
     io.MousePos = ImVec2((float)ofGetMouseX(), (float)ofGetMouseY());
     for(int i = 0; i < 5; i++){
         io.MouseDown[i] = engine->mousePressed[i];
-        engine->mousePressed[i] = engine->mouseDragged || false;    // Don't set to false if the mouse is being dragged
+        
+        // Update for next frame; set to false only if the mouse has been released
+        engine->mousePressed[i] = !engine->mouseReleased;
     }
     ImGui::NewFrame();
 }


### PR DESCRIPTION
After reviewing the ImGui code and examples, I discovered that their code does not set io.MouseDown to false when the mouse is released. Instead, io.MouseDown is set to false one frame later. I've implemented a solution very similar to the ImGui example code; this resolves #37.