### PR TITLE
Update EngineOpenGLES.cpp

### DIFF
--- a/src/EngineOpenGLES.cpp
+++ b/src/EngineOpenGLES.cpp
@@ -127,7 +127,7 @@ namespace ofxImGui
 
 		g_UniformLocationTex = glGetUniformLocation(g_ShaderHandle, "Texture");
 		g_UniformLocationProjMtx = glGetUniformLocation(g_ShaderHandle, "ProjMat");
-		g_UniformLocationPosition = glGetAttribLocation(g_ShaderHandle, "Position");
+		g_AttribLocationPosition = glGetAttribLocation(g_ShaderHandle, "Position");
 		g_AttribLocationUV = glGetAttribLocation(g_ShaderHandle, "UV");
 		g_AttribLocationColor = glGetAttribLocation(g_ShaderHandle, "Color");
 


### PR DESCRIPTION
Fix compilation error: "../../../addons/ofxImGui/src/EngineOpenGLES.cpp:130:3: error: ‘g_UniformLocationPosition’ was not declared in this scope g_UniformLocationPosition = glGetAttribLocation(g_ShaderHandle, "Position");"