### PR TITLE
Std explicit

### DIFF
--- a/src/BaseEngine.cpp
+++ b/src/BaseEngine.cpp
@@ -77,7 +77,7 @@ namespace ofxImGui
 	}
 
 	//--------------------------------------------------------------
-	GLuint BaseEngine::loadTextureImage2D(unsigned char * pixels, int width, int height)
+	unsigned int BaseEngine::loadTextureImage2D(unsigned char * pixels, int width, int height)
 	{
 		GLint last_texture;
 		glGetIntegerv(GL_TEXTURE_BINDING_2D, &last_texture);

--- a/src/BaseEngine.h
+++ b/src/BaseEngine.h
@@ -29,7 +29,7 @@ namespace ofxImGui
 		virtual void onKeyReleased(ofKeyEventArgs& event) = 0;
 		virtual void onWindowResized(ofResizeEventArgs& window);
 
-		virtual GLuint loadTextureImage2D(unsigned char * pixels, int width, int height);
+		virtual unsigned int loadTextureImage2D(unsigned char * pixels, int width, int height);
 
 		static const char* getClipboardString();
 		static void setClipboardString(const char * text);

--- a/src/BaseTheme.cpp
+++ b/src/BaseTheme.cpp
@@ -1,6 +1,7 @@
 #include "BaseTheme.h"
 
 #include "imgui.h"
+using namespace std;
 
 namespace ofxImGui
 {

--- a/src/BaseTheme.h
+++ b/src/BaseTheme.h
@@ -22,7 +22,7 @@ namespace ofxImGui
 		ofColor col_win_popup;
 		ofColor col_win_backg;
 
-		bool addColorEdit(string label, ofColor& color);
+		bool addColorEdit( std::string label, ofColor& color);
 		ofColor convertColor(float* f);
 	};
 }

--- a/src/EngineVk.cpp
+++ b/src/EngineVk.cpp
@@ -263,7 +263,7 @@ namespace ofxImGui
 	}
 	
 
-	static const std::string cImGuiFragmentShaderSource = R"~glsl~(
+static const std::string cImGuiFragmentShaderSource = R"~glsl~(
 #version 450 core
 
 #extension GL_ARB_separate_shader_objects : enable
@@ -283,40 +283,41 @@ void main(){
 }
 )~glsl~";
 
-	static const std::string cImGuiVertexShaderSource =
-		"#version 450 core\n"
-		"\n"
-		"#extension GL_ARB_separate_shader_objects : enable\n"
-		"#extension GL_ARB_shading_language_420pack : enable\n"
-		"\n"
-		"// uniforms (resources)\n"
-		"layout (set = 0, binding = 0) uniform DefaultMatrices \n"
-		"{\n"
-		"	mat4 modelViewProjectionMatrix;\n"
-		"};\n"
-		"\n"
-		"// inputs (vertex attributes)\n"
-		"layout (location = 0) in vec2 inPos;\n"
-		"layout (location = 1) in vec2 inTexCoord;\n"
-		"layout (location = 2) in vec4 inColor;\n"
-		"\n"
-		"// outputs \n"
-		"layout (location = 0) out vec4 outColor;\n"
-		"layout (location = 1) out vec2 outTexCoord;\n"
-		"\n"
-		"// we override the built-in fixed function outputs\n"
-		"// to have more control over the SPIR-V code created.\n"
-		"out gl_PerVertex\n"
-		"{\n"
-		"    vec4 gl_Position;\n"
-		"};\n"
-		"\n"
-		"void main()\n"
-		"{\n"
-		"	outTexCoord = inTexCoord;\n"
-		"	outColor = inColor;\n"
-		"	gl_Position = modelViewProjectionMatrix * vec4(inPos,0,1);\n"
-		"}\n";
+static const std::string cImGuiVertexShaderSource = R"~glsl~(
+#version 450 core
+
+#extension GL_ARB_separate_shader_objects : enable
+#extension GL_ARB_shading_language_420pack : enable
+		
+// uniforms (resources)
+layout (set = 0, binding = 0) uniform DefaultMatrices
+{
+	mat4 modelViewProjectionMatrix;
+};
+		
+// inputs (vertex attributes)
+layout (location = 0) in vec2 inPos;
+layout (location = 1) in vec2 inTexCoord;
+layout (location = 2) in vec4 inColor;
+		
+// outputs
+layout (location = 0) out vec4 outColor;
+layout (location = 1) out vec2 outTexCoord;
+		
+// we override the built-in fixed function outputs
+// to have more control over the SPIR-V code created.
+out gl_PerVertex
+{
+	vec4 gl_Position;
+};
+
+void main()
+{
+	outTexCoord = inTexCoord;
+	outColor = inColor;
+	gl_Position = modelViewProjectionMatrix * vec4(inPos,0,1);
+}
+)~glsl~";
 
 
 	//--------------------------------------------------------------

--- a/src/EngineVk.cpp
+++ b/src/EngineVk.cpp
@@ -99,8 +99,8 @@ namespace ofxImGui
 				allocatorSettings.physicalDeviceMemoryProperties = rendererProperties.physicalDeviceMemoryProperties;
 				allocatorSettings.physicalDeviceProperties = rendererProperties.physicalDeviceProperties;
 
-				mImageAllocator = std::make_unique<of::vk::ImageAllocator>( allocatorSettings );
-				mImageAllocator->setup();
+				mImageAllocator = std::make_unique<of::vk::ImageAllocator>(  );
+				mImageAllocator->setup(allocatorSettings);
 		}
 	}
 
@@ -176,7 +176,7 @@ namespace ofxImGui
 			return;
 		draw_data->ScaleClipRects(io.DisplayFramebufferScale);
 
-		auto & alloc = batch->getContext()->getTransientAllocator();
+		auto & alloc = batch->getContext()->getAllocator();
 
 		::vk::DeviceSize offset = 0;
 		void * dataP = nullptr;
@@ -427,7 +427,7 @@ namespace ofxImGui
 		imgData.extent.width = width;
 		imgData.extent.height = height;
 
-		mFontImage = mRenderer->getStagingContext()->storeImageCmd( imgData, mImageAllocator );
+		mFontImage = mRenderer->getStagingContext()->storeImageCmd( imgData, *mImageAllocator );
 
 		::vk::SamplerCreateInfo samplerInfo = of::vk::Texture::getDefaultSamplerCreateInfo();
 		

--- a/src/EngineVk.h
+++ b/src/EngineVk.h
@@ -54,7 +54,7 @@ namespace ofxImGui
 		static ::of::vk::RenderBatch*                   batch;           // Current batch used for drawing
 		static std::unique_ptr<of::vk::ImageAllocator>  mImageAllocator; // Allocator used for font texture
 		static std::shared_ptr<::vk::Image>             mFontImage;      // Data store for image data
-		static std::shared_ptr<of::vk::Texture>         mFontTexture;    // Wrapper with sampler around font texture
+		static of::vk::Texture                          mFontTexture;    // Wrapper with sampler around font texture
 		static std::unique_ptr<of::vk::DrawCommand>     mDrawCommand;    // Used to draw ImGui components
 		
 		void createDrawCommands();

--- a/src/Gui.cpp
+++ b/src/Gui.cpp
@@ -12,6 +12,9 @@
 
 namespace ofxImGui
 {
+
+	using namespace std;
+
 	//--------------------------------------------------------------
 	Gui::Gui()
 		: lastTime(0.0f)

--- a/src/Gui.h
+++ b/src/Gui.h
@@ -29,14 +29,14 @@ namespace ofxImGui
 		BaseTheme* theme;
 
 		GLuint loadImage(ofImage& image);
-		GLuint loadImage(string imagePath);
+		GLuint loadImage( std::string imagePath);
 
-		GLuint loadPixels(string imagePath);
+		GLuint loadPixels( std::string imagePath);
 		GLuint loadPixels(ofPixels& pixels);
 
-		GLuint loadTexture(string imagePath);
-		GLuint loadTexture(ofTexture& texture, string imagePath);
+		GLuint loadTexture( std::string imagePath);
+		GLuint loadTexture(ofTexture& texture, std::string imagePath);
 
-		vector<ofTexture*> loadedTextures;
+		std::vector<ofTexture*> loadedTextures;
 	};
 }

--- a/src/Helpers.cpp
+++ b/src/Helpers.cpp
@@ -1,5 +1,7 @@
 #include "Helpers.h"
 
+using namespace std;
+
 //--------------------------------------------------------------
 ofxImGui::Settings::Settings()
 	: windowPos(kImGuiMargin, kImGuiMargin)
@@ -18,7 +20,7 @@ const char * ofxImGui::GetUniqueName(ofAbstractParameter& parameter)
 //--------------------------------------------------------------
 const char * ofxImGui::GetUniqueName(const std::string& candidate)
 {
-	std::string result = candidate;
+	string result = candidate;
 	while (std::find(windowOpen.usedNames.top().begin(), windowOpen.usedNames.top().end(), result) != windowOpen.usedNames.top().end())
 	{
 		result += " ";
@@ -64,7 +66,7 @@ bool ofxImGui::BeginWindow(const string& name, Settings& settings, bool collapse
 	settings.windowBlock = true;
 
 	// Push a new list of names onto the stack.
-	windowOpen.usedNames.push(std::vector<std::string>());
+	windowOpen.usedNames.push(vector<string>());
 
 	ImGui::SetNextWindowPos(settings.windowPos, ImGuiSetCond_Appearing);
 	ImGui::SetNextWindowSize(settings.windowSize, ImGuiSetCond_Appearing);
@@ -84,7 +86,7 @@ bool ofxImGui::BeginWindow(const string& name, Settings& settings, ImGuiWindowFl
 	settings.windowBlock = true;
 
 	// Push a new list of names onto the stack.
-	windowOpen.usedNames.push(std::vector<std::string>());
+	windowOpen.usedNames.push(vector<string>());
 
 	ImGui::SetNextWindowPos(settings.windowPos, ImGuiSetCond_Appearing);
 	ImGui::SetNextWindowSize(settings.windowSize, ImGuiSetCond_Appearing);
@@ -152,7 +154,7 @@ bool ofxImGui::BeginTree(const string& name, Settings& settings)
 		settings.treeLevel += 1;
 
 		// Push a new list of names onto the stack.
-		windowOpen.usedNames.push(std::vector<std::string>());
+		windowOpen.usedNames.push(vector<string>());
 	}
 	return result;
 }

--- a/src/Helpers.h
+++ b/src/Helpers.h
@@ -12,7 +12,7 @@ namespace ofxImGui
 	struct WindowOpen
 	{
 		std::stack<std::vector<std::string>> usedNames;
-		shared_ptr<ofParameter<bool>> parameter;
+		std::shared_ptr<ofParameter<bool>> parameter;
 		bool value;
 	};
 
@@ -37,12 +37,12 @@ namespace ofxImGui
 
 	void SetNextWindow(Settings& settings);
 	bool BeginWindow(ofParameter<bool>& parameter, Settings& settings, bool collapse = true);
-	bool BeginWindow(const string& name, Settings& settings, bool collapse = true, bool * open = nullptr);
-	bool BeginWindow(const string& name, Settings& settings, ImGuiWindowFlags flags, bool * open = nullptr);
+	bool BeginWindow(const std::string& name, Settings& settings, bool collapse = true, bool * open = nullptr);
+	bool BeginWindow(const std::string& name, Settings& settings, ImGuiWindowFlags flags, bool * open = nullptr);
 	void EndWindow(Settings& settings);
 
 	bool BeginTree(ofAbstractParameter& parameter, Settings& settings);
-	bool BeginTree(const string& name, Settings& settings);
+	bool BeginTree(const std::string& name, Settings& settings);
 	void EndTree(Settings& settings);
 
 	void AddGroup(ofParameterGroup& group, Settings& settings);
@@ -66,27 +66,27 @@ namespace ofxImGui
 	template<typename ParameterType>
 	bool AddParameter(ofParameter<ParameterType>& parameter);
 
-	bool AddRadio(ofParameter<int>& parameter, vector<string> labels, int columns = 1);
+	bool AddRadio(ofParameter<int>& parameter, std::vector<std::string> labels, int columns = 1);
 	bool AddStepper(ofParameter<int>& parameter, int step = 1, int stepFast = 100);
 
-	bool AddRange(const string& name, ofParameter<float>& parameterMin, ofParameter<float>& parameterMax, float speed = 0.01f);
+	bool AddRange(const std::string& name, ofParameter<float>& parameterMin, ofParameter<float>& parameterMax, float speed = 0.01f);
 
 #if OF_VERSION_MINOR >= 10
-	bool AddValues(const string& name, vector<glm::ivec2>& values, int minValue, int maxValue);
-	bool AddValues(const string& name, vector<glm::ivec3>& values, int minValue, int maxValue);
-	bool AddValues(const string& name, vector<glm::ivec4>& values, int minValue, int maxValue);
+	bool AddValues(const std::string& name, std::vector<glm::ivec2>& values, int minValue, int maxValue);
+	bool AddValues(const std::string& name, std::vector<glm::ivec3>& values, int minValue, int maxValue);
+	bool AddValues(const std::string& name, std::vector<glm::ivec4>& values, int minValue, int maxValue);
 
-	bool AddValues(const string& name, vector<glm::vec2>& values, float minValue, float maxValue);
-	bool AddValues(const string& name, vector<glm::vec3>& values, float minValue, float maxValue);
-	bool AddValues(const string& name, vector<glm::vec4>& values, float minValue, float maxValue);
+	bool AddValues(const std::string& name, std::vector<glm::vec2>& values, float minValue, float maxValue);
+	bool AddValues(const std::string& name, std::vector<glm::vec3>& values, float minValue, float maxValue);
+	bool AddValues(const std::string& name, std::vector<glm::vec4>& values, float minValue, float maxValue);
 #endif
 
-	bool AddValues(const string& name, vector<ofVec2f>& values, float minValue, float maxValue);
-	bool AddValues(const string& name, vector<ofVec3f>& values, float minValue, float maxValue);
-	bool AddValues(const string& name, vector<ofVec4f>& values, float minValue, float maxValue);
+	bool AddValues(const std::string& name, std::vector<ofVec2f>& values, float minValue, float maxValue);
+	bool AddValues(const std::string& name, std::vector<ofVec3f>& values, float minValue, float maxValue);
+	bool AddValues(const std::string& name, std::vector<ofVec4f>& values, float minValue, float maxValue);
 
 	template<typename DataType>
-	bool AddValues(const string& name, vector<DataType>& values, DataType minValue, DataType maxValue);
+	bool AddValues(const std::string& name, std::vector<DataType>& values, DataType minValue, DataType maxValue);
 
 	void AddImage(ofBaseHasTexture& hasTexture, const ofVec2f& size);
 	void AddImage(ofTexture& texture, const ofVec2f& size);
@@ -137,7 +137,7 @@ bool ofxImGui::AddParameter(ofParameter<ParameterType>& parameter)
 
 //--------------------------------------------------------------
 template<typename DataType>
-bool ofxImGui::AddValues(const string& name, vector<DataType>& values, DataType minValue, DataType maxValue)
+bool ofxImGui::AddValues(const std::string& name, std::vector<DataType>& values, DataType minValue, DataType maxValue)
 {
 	auto result = false;
 	const auto& info = typeid(DataType);

--- a/src/ofxImGuiLoggerChannel.cpp
+++ b/src/ofxImGuiLoggerChannel.cpp
@@ -1,5 +1,7 @@
 #include "ofxImGuiLoggerChannel.h"
 
+using namespace std;
+
 //--------------------------------------------------------------
 
 ImGuiTextBuffer& ofxImGui::LoggerChannel::getBuffer(){

--- a/src/ofxImGuiLoggerChannel.h
+++ b/src/ofxImGuiLoggerChannel.h
@@ -14,9 +14,9 @@ public:
 
 	/// \brief Destroy the console logger channel.
 	virtual ~LoggerChannel(){};
-	void log( ofLogLevel level, const string & module, const string & message );
-	void log( ofLogLevel level, const string & module, const char* format, ... ) OF_PRINTF_ATTR( 4, 5 );
-	void log( ofLogLevel level, const string & module, const char* format, va_list args );
+	void log( ofLogLevel level, const std::string & module, const std::string & message );
+	void log( ofLogLevel level, const std::string & module, const char* format, ... ) OF_PRINTF_ATTR( 4, 5 );
+	void log( ofLogLevel level, const std::string & module, const char* format, std::va_list args );
 };
 
 } // end namespace ofxImGui


### PR DESCRIPTION
use explicit `std`, in header files, `using namespace std` in .cpp files. This is necessary for latest openFrameworks, which (finally) has more stricter handling of namespaces.

* also inlines glsl for engineVk