### PR TITLE
fix memory leak in ofxImGui::Gui

### DIFF
--- a/src/Gui.cpp
+++ b/src/Gui.cpp
@@ -36,11 +36,14 @@ namespace ofxImGui
 		io.DisplaySize = ImVec2((float)ofGetWidth(), (float)ofGetHeight());
 		io.MouseDrawCursor = false;
 
+		if (engine)
+			delete engine;
+
 #if defined(TARGET_OPENGLES)
 		engine = new EngineOpenGLES();
 #elif defined (OF_TARGET_API_VULKAN) 
 		engine = new EngineVk();
-#else 
+#else
 		engine = new EngineGLFW();
 #endif
 


### PR DESCRIPTION
Maybe a better fix would be using smart pointers (specifically `unique_ptr`) to make this kind of mistake impossible.