### PR TITLE
Test rm pointers

### DIFF
--- a/example-demo/src/main.cpp
+++ b/example-demo/src/main.cpp
@@ -13,7 +13,7 @@ int main()
 {
     ofSetLogLevel(OF_LOG_VERBOSE);
 #if defined(TARGET_OPENGLES)
-    #if (OF_VERSION_MINOR == 9)
+    #if (OF_VERSION_MINOR >= 9)
         ofGLESWindowSettings settings;
 		settings.setSize(1280, 720);
         settings.setGLESVersion(2);

--- a/src/EngineGLFW.cpp
+++ b/src/EngineGLFW.cpp
@@ -509,7 +509,7 @@ namespace ofxImGui
 		{
 			glDeleteTextures(1, &g_FontTexture);
             //JVC: This is causing an error
-			//ImGui::GetIO().Fonts->TexID = 0;
+			ImGui::GetIO().Fonts->TexID = 0;
 			g_FontTexture = 0;
 		}
 	}

--- a/src/EngineGLFW.cpp
+++ b/src/EngineGLFW.cpp
@@ -70,22 +70,24 @@ namespace ofxImGui
 		isSetup = true;
 	}
 
+    
+    
 	//--------------------------------------------------------------
 	void EngineGLFW::exit()
 	{
 		if (!isSetup) return;
-
-		// Override listeners
-		ofRemoveListener(ofEvents().mousePressed, this, &EngineGLFW::onMousePressed);
-		ofRemoveListener(ofEvents().mouseReleased, this, &EngineGLFW::onMouseReleased);
-		ofRemoveListener(ofEvents().keyReleased, this, &EngineGLFW::onKeyReleased);
-		ofRemoveListener(ofEvents().keyPressed, this, &EngineGLFW::onKeyPressed);
-
-		// Base class listeners
-		ofRemoveListener(ofEvents().mouseDragged, (BaseEngine*)this, &BaseEngine::onMouseDragged);
-		ofRemoveListener(ofEvents().mouseScrolled, (BaseEngine*)this, &BaseEngine::onMouseScrolled);
-		ofRemoveListener(ofEvents().windowResized, (BaseEngine*)this, &BaseEngine::onWindowResized);
-
+        
+        // Override listeners
+        ofRemoveListener(ofEvents().mousePressed, this, &EngineGLFW::onMousePressed);
+        ofRemoveListener(ofEvents().mouseReleased, this, &EngineGLFW::onMouseReleased);
+        ofRemoveListener(ofEvents().keyReleased, this, &EngineGLFW::onKeyReleased);
+        ofRemoveListener(ofEvents().keyPressed, this, &EngineGLFW::onKeyPressed);
+        
+        // Base class listeners
+        ofRemoveListener(ofEvents().mouseDragged, (BaseEngine*)this, &BaseEngine::onMouseDragged);
+        ofRemoveListener(ofEvents().mouseScrolled, (BaseEngine*)this, &BaseEngine::onMouseScrolled);
+        ofRemoveListener(ofEvents().windowResized, (BaseEngine*)this, &BaseEngine::onWindowResized);
+        
 		invalidateDeviceObjects();
 
 		isSetup = false;
@@ -506,7 +508,8 @@ namespace ofxImGui
 		if (g_FontTexture)
 		{
 			glDeleteTextures(1, &g_FontTexture);
-			ImGui::GetIO().Fonts->TexID = 0;
+            //JVC: This is causing an error
+			//ImGui::GetIO().Fonts->TexID = 0;
 			g_FontTexture = 0;
 		}
 	}

--- a/src/Gui.cpp
+++ b/src/Gui.cpp
@@ -47,7 +47,7 @@ namespace ofxImGui
 	//--------------------------------------------------------------
 	void Gui::exit()
 	{
-     
+        engine.exit();
 		if (theme)
 		{
 			delete theme;

--- a/src/Gui.h
+++ b/src/Gui.h
@@ -4,7 +4,14 @@
 #include "ofPixels.h"
 #include "ofTexture.h"
 
-#include "BaseEngine.h"
+#if defined(TARGET_OPENGLES)
+#include "EngineOpenGLES.h"
+#elif defined (OF_TARGET_API_VULKAN)
+#include "EngineVk.h"
+#else
+#include "EngineGLFW.h"
+#endif
+
 #include "BaseTheme.h"
 
 namespace ofxImGui
@@ -35,9 +42,15 @@ namespace ofxImGui
 		GLuint loadTexture(const std::string& imagePath);
 		GLuint loadTexture(ofTexture& texture, const std::string& imagePath);
 
-	private:
-		BaseEngine* engine;
-
+	private:        
+#if defined(TARGET_OPENGLES)
+        EngineOpenGLES engine;
+#elif defined (OF_TARGET_API_VULKAN) 
+        EngineVk engine;
+#else
+        EngineGLFW engine;
+#endif
+        
 		float lastTime;
 		bool autoDraw;
 


### PR DESCRIPTION
I was having some crashes on close on the Mac (ofRemoveListener...) and I don't think the dtors were being called properly.

I removed the engine pointer and just choose the engine at compile time and it seemed to clear up

~~However doing this caused another error here:
https://github.com/jvcleave/ofxImGui/blob/test_rm_pointers/src/EngineGLFW.cpp#L512~~
edit: https://github.com/jvcleave/ofxImGui/pull/85/commits/1399cb10c7dd487f2947be0a6c43cd268c87acb2 seems to fix

I've tested this on MacOS 0.13.6/ OF 0.10.0 and the RPi but not much more than some simple apps and the examples