### PR TITLE
add capture of stdout for the LoggerChannel

### DIFF
--- a/src/ofxImGuiLoggerChannel.cpp
+++ b/src/ofxImGuiLoggerChannel.cpp
@@ -1,10 +1,19 @@
 #include "ofxImGuiLoggerChannel.h"
+#include <streambuf>
 
 //--------------------------------------------------------------
+std::stringstream ofxImGui::LoggerChannel::buffer;
+std::streambuf * ofxImGui::LoggerChannel::old = NULL;
 
 ImGuiTextBuffer& ofxImGui::LoggerChannel::getBuffer(){
 	static ImGuiTextBuffer sLogBuffer; // static log buffer for logger channel
-	return sLogBuffer;
+    if ( ! buffer.str().empty() )
+    {
+        sLogBuffer.appendf("%s", buffer.str().c_str());
+        buffer.clear();
+        buffer.str(std::string());
+    }
+    return sLogBuffer;
 };
 
 //--------------------------------------------------------------
@@ -24,5 +33,8 @@ void ofxImGui::LoggerChannel::log( ofLogLevel level, const std::string & module,
 	getBuffer().appendfv( format, args );
 }
 
-
+void ofxImGui::LoggerChannel::capture_stdout()
+{
+    old = std::cout.rdbuf(buffer.rdbuf());
+}
 //--------------------------------------------------------------

--- a/src/ofxImGuiLoggerChannel.h
+++ b/src/ofxImGuiLoggerChannel.h
@@ -10,13 +10,18 @@ class LoggerChannel : public ofBaseLoggerChannel
 {
 public:
 
-	static ImGuiTextBuffer & getBuffer();
+    static std::stringstream buffer;
+    static std::streambuf * old;
+
+    static ImGuiTextBuffer & getBuffer();
 
 	/// \brief Destroy the console logger channel.
-	virtual ~LoggerChannel(){};
+    virtual ~LoggerChannel(){}
 	void log( ofLogLevel level, const std::string & module, const std::string & message );
 	void log( ofLogLevel level, const std::string & module, const char* format, ... ) OF_PRINTF_ATTR( 4, 5 );
 	void log( ofLogLevel level, const std::string & module, const char* format, va_list args );
+
+    void capture_stdout();
 };
 
 } // end namespace ofxImGui


### PR DESCRIPTION
Perhaps this is handy for more people?

To use:
```
channel = std::shared_ptr<ofxImGui::LoggerChannel>(new ofxImGui::LoggerChannel());
channel->capture_stdout();
```
