### PR TITLE
handling multiwindow

### DIFF
--- a/example-multiwindow/addons.make
+++ b/example-multiwindow/addons.make
@@ -1,0 +1,1 @@
+ofxImGui

--- a/example-multiwindow/src/main.cpp
+++ b/example-multiwindow/src/main.cpp
@@ -1,0 +1,22 @@
+#include "ofMain.h"
+#include "ofApp.h"
+#include "ofAppGLFWWindow.h"
+
+//========================================================================
+int main( ){
+	ofGLFWWindowSettings settings;
+	settings.setSize(300, 300);
+	settings.setPosition(ofVec2f(0, 100));
+	auto window1 = ofCreateWindow(settings);
+
+	settings.setPosition(ofVec2f(300, 100));
+	auto window2 = ofCreateWindow(settings);
+
+	auto app1 = std::make_shared<ofApp>();
+	auto app2 = std::make_shared<ofApp>();
+
+	ofRunApp(window1, app1);
+	ofRunApp(window2, app2);
+
+	ofRunMainLoop();
+}

--- a/example-multiwindow/src/ofApp.cpp
+++ b/example-multiwindow/src/ofApp.cpp
@@ -1,0 +1,1 @@
+#include "ofApp.h"

--- a/example-multiwindow/src/ofApp.h
+++ b/example-multiwindow/src/ofApp.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "ofMain.h"
+#include "ofxImGui.h"
+
+class ofApp : public ofBaseApp{
+
+	public:
+		ofApp() : v(0) {}
+
+		void setup() {
+			gui.setup();
+		}
+		void draw() {
+			gui.begin();
+			ImGui::SliderFloat("slider", &v, 0.f, 10.f);
+			gui.end();
+		}
+
+	private:
+		ofxImGui::Gui gui;
+		float v;
+};

--- a/src/Gui.cpp
+++ b/src/Gui.cpp
@@ -11,7 +11,7 @@ namespace ofxImGui
 		: lastTime(0.0f)
 		, theme(nullptr)
 	{
-		ImGui::CreateContext();
+		context = ImGui::CreateContext();
 	}
 
 	//--------------------------------------------------------------
@@ -23,7 +23,7 @@ namespace ofxImGui
 	//--------------------------------------------------------------
 	void Gui::setup(BaseTheme* theme_, bool autoDraw_)
 	{
-		ImGui::CreateContext();
+		ImGui::SetCurrentContext(context);
 		ImGuiIO& io = ImGui::GetIO();
 
 		io.DisplaySize = ImVec2((float)ofGetWidth(), (float)ofGetHeight());
@@ -64,7 +64,7 @@ namespace ofxImGui
 		}
 		loadedTextures.clear();
 
-		ImGui::DestroyContext();
+		ImGui::DestroyContext(context);
 	}
 
 	//--------------------------------------------------------------
@@ -138,7 +138,7 @@ namespace ofxImGui
 	void Gui::begin()
 	{
 		
-
+		ImGui::SetCurrentContext(context);
 		ImGuiIO& io = ImGui::GetIO();
 
 		float currentTime = ofGetElapsedTimef();

--- a/src/Gui.h
+++ b/src/Gui.h
@@ -56,5 +56,6 @@ namespace ofxImGui
 		BaseTheme* theme;
 
 		std::vector<ofTexture*> loadedTextures;
+		ImGuiContext* context;
 	};
 }


### PR DESCRIPTION
# Summary

I modified ImGui's context handling so that I can handle multi window app which has ofxImGui at each windows.
In current master, there are several problems at multi window situation.

- Because of using one global ImGuiContext, we can't drag or collapse ImGuiWindows. These behaviers are bit different by OS though.
- App will crash at exit, because double-free of ImGuiContext

# About test app

I added small app named 'example-multiwindow'.

I think you can check by following steps.

1. copy example-multiwindow to myApps, then create project file by ProjectGenerator
2. checkout current master of ofxImGui and problems are shown.
3. checkout my 'multiwindow' branch and rebuild app, then problems are clear.

# Tested env

- windows10, oF 0.10.1, VisualStudio2017
- macos mojave, oF 0.10.1, Xcode10.2



'example-multiwindow' might be unnecessary for master, I can rebase or remove that before merge.

Thank you for your great addon, any feedback is very welcome.!