### PR TITLE
include <stack>

### DIFF
--- a/src/ImHelpers.h
+++ b/src/ImHelpers.h
@@ -6,6 +6,7 @@
 #include "ofTexture.h"
 #include "ofGLBaseTypes.h"
 #include "imgui.h"
+#include <stack>
 
 static const int kImGuiMargin = 10;
 


### PR DESCRIPTION
it complains in macOS
```
ImHelpers.h:24:8: error: no template named 'stack' in namespace 'std'
```