### PR TITLE
imgui_impl_glfw.cpp Obj-C support

### DIFF
--- a/libs/imgui/backends/imgui_impl_glfw.cpp
+++ b/libs/imgui/backends/imgui_impl_glfw.cpp
@@ -668,7 +668,7 @@ static bool ImGui_ImplGlfw_Init(GLFWwindow* window, bool install_callbacks, Glfw
 #ifdef _WIN32
     main_viewport->PlatformHandleRaw = glfwGetWin32Window(bd->Window);
 #elif defined(__APPLE__)
-    main_viewport->PlatformHandleRaw = (void*)glfwGetCocoaWindow(bd->Window);
+    main_viewport->PlatformHandleRaw = (void*)CFBridgingRetain(glfwGetCocoaWindow(bd->Window));
 #else
     IM_UNUSED(main_viewport);
 #endif
@@ -1086,7 +1086,7 @@ static void ImGui_ImplGlfw_CreateWindow(ImGuiViewport* viewport)
 #ifdef _WIN32
     viewport->PlatformHandleRaw = glfwGetWin32Window(vd->Window);
 #elif defined(__APPLE__)
-    viewport->PlatformHandleRaw = (void*)glfwGetCocoaWindow(vd->Window);
+    viewport->PlatformHandleRaw = (void*)CFBridgingRetain(glfwGetCocoaWindow(vd->Window));
 #endif
     glfwSetWindowPos(vd->Window, (int)viewport->Pos.x, (int)viewport->Pos.y);
 


### PR DESCRIPTION
Fix for Mac Intel build error `error: cast of Objective-C pointer type 'id' to C pointer type 'void *' requires a bridged cast`